### PR TITLE
Support ISO 8601 formatted date

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ The data fields returned from the datasource should be mapped with the following
 
 | Column               | Default Value | Description                                                                                                                                         |
 |----------------------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Time From Field**   | time_from    | **Required**<br>A UNIX Timestamp (`Number`)<br>This will set the "From" part of the time range.<br>The value can include or exclude ms. Example: 1612413008000 or 1612413008  |
-| **Time To Field**     | time_to      | _Optional_<br>A UNIX Timestamp (`Number`)<br>This will set the "To" part of the time range.  <br>The value can include or exclude ms. Example: 1612413008000 or 1612413008<br>_If this is not supplied, it will default to `now`._ |
+| **Time From Field**   | time_from    | **Required**<br>A UNIX Timestamp (`Number`) or ISO 8601 formatted date<br>This will set the "From" part of the time range.<br>The value can include or exclude ms. Example: 1612413008000 or 1612413008  |
+| **Time To Field**     | time_to      | _Optional_<br>A UNIX Timestamp (`Number`) or ISO 8601 formatted date<br>This will set the "To" part of the time range.  <br>The value can include or exclude ms. Example: 1612413008000 or 1612413008<br>_If this is not supplied, it will default to `now`._ |
 | **Button Text Field** | button_text  | _Optional_<br>What the text inside the button will say.<br>_If this is not supplied, it will default to a locale-formatted timestamp._              |
 | **Primary Field**     | primary      | _Optional_<br>Field used to determine if the button will be marked with a `star` icon                                                         |
 | **Primary Value**     | 1            | _Optional_<br>A Regex pattern to perform on the `Primary Field`. If matched the button will be marked with a `star` icon.                                                         |

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -42,7 +42,7 @@ export const Panel: React.FC<Props> = ({ options, data, width, height }) => {
         button.errors.push(`'${options.timeFromOption}' value is required`);
       } else {
         // Check it's a valid UNIX timestamp
-        button.time_from = Number(button.time_from);
+        button.time_from = Date.parse(String(button.time_from)) || Number(button.time_from);
         if (isNaN(button.time_from)) {
           button.errors.push(`'${options.timeFromOption}' is not a valid UNIX timestamp`);
         } else if (typeof button.text === 'undefined' || button.text === null) {
@@ -57,7 +57,7 @@ export const Panel: React.FC<Props> = ({ options, data, width, height }) => {
       // Sanitize time_to
       if (typeof button.time_to !== 'undefined' && button.time_to !== null) {
         // Check it's a valid UNIX timestamp
-        button.time_to = Number(button.time_to);
+        button.time_to = Date.parse(String(button.time_to)) || Number(button.time_to);
         if (isNaN(button.time_to)) {
           button.errors.push(`'${options.timeToOption}' is not a valid UNIX timestamp`);
         }


### PR DESCRIPTION
Since version 2.0.0 of `grafana-timepicker-buttons`, support for date strings was dropped, which meant a time column queried from influxdb wouldn't work unless the user resorted to some [hacky approach](https://github.com/WilliamVenner/grafana-timepicker-buttons/issues/10#issuecomment-859478550).

This PR adds back support for date strings, including ISO 8601 formatted dates.

